### PR TITLE
Fixes

### DIFF
--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -1039,7 +1039,7 @@ def _build_portfolio_from_df(data, pf_allocation=None, datacolumns=["Adj. Close"
         # get name of stock
         name = pf_allocation.loc[i].Name
         # extract data column(s) of said stock
-        stock_data = data.filter(regex=name).copy(deep=True)
+        stock_data = data.loc[:,[name]].copy(deep=True)
         # if only one data column per stock exists, give dataframe a name
         if len(datacolumns) == 1:
             stock_data.name = datacolumns[0]

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -59,11 +59,11 @@ def sharpe_ratio(exp_return, volatility, risk_free_rate=0.005):
     :Output:
      :sharpe ratio: ``float`` ``(exp_return - risk_free_rate)/float(volatility)``
     """
-    if not isinstance(exp_return, (int, float, np.int64, np.float64)):
+    if not isinstance(exp_return, (int, float, np.int32, np.int64, np.float32, np.float64)):
         raise ValueError("exp_return is expected to be an integer or float.")
-    if not isinstance(volatility, (int, float, np.int64, np.float64)):
+    if not isinstance(volatility, (int, float, np.int32, np.int64, np.float32, np.float64)):
         raise ValueError("volatility is expected to be an integer or float.")
-    if not isinstance(risk_free_rate, (int, float, np.int64, np.float64)):
+    if not isinstance(risk_free_rate, (int, float, np.int32, np.int64, np.float32, np.float64)):
         raise ValueError("risk_free_rate is expected to be an integer or float.")
     return (exp_return - risk_free_rate) / float(volatility)
 

--- a/finquant/returns.py
+++ b/finquant/returns.py
@@ -17,7 +17,7 @@ def cumulative_returns(data, dividend=0):
     :Output:
      :ret: a ``pandas.DataFrame`` of cumulative Returns of given stock prices.
     """
-    return data.apply(lambda x: (x - x[0] + dividend) / x[0])
+    return data.dropna(axis=0, how='any').apply(lambda x: (x - x[0] + dividend) / x[0])
 
 
 def daily_returns(data):

--- a/finquant/returns.py
+++ b/finquant/returns.py
@@ -32,7 +32,7 @@ def daily_returns(data):
      :ret: a ``pandas.DataFrame`` of daily percentage change of Returns
          of given stock prices.
     """
-    return data.pct_change().dropna(how="all")
+    return data.pct_change().dropna(how="all").replace([np.inf, -np.inf], np.nan)
 
 
 def daily_log_returns(data):


### PR DESCRIPTION
Hi, I was working with the program and encountered some issues. After some debugging, I came up with two possible fixes:

- Using regex to select stock data when building portfolio can cause an error, if tickers are similar (e.g. CE and CEO), all will be picked up at once, eventually causing dimension mismatches. I propose to use DataFrame `loc` instead.

- `pct_change` can return `inf` in some data points from yfinance, causing subsequent errors. I propose adding something to replace `inf` with `nan`, which will be handled correctly by pandas.

Thanks.