### PR TITLE
For yfinance make single stock dataframe multiindex

### DIFF
--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -798,6 +798,10 @@ def _yfinance_request(names, start_date=None, end_date=None):
     # thus we do not need to correct them
     try:
         resp = yf.download(names, start=start_date, end=end_date)
+        if not isinstance(resp.columns, pd.core.index.MultiIndex) and len(names) > 0:
+            # for single stock must make the dataframe multiindex
+            stock_tuples = [(col, names[0]) for col in list(resp.columns)]
+            resp.columns = pd.MultiIndex.from_tuples(stock_tuples)
     except Exception:
         raise Exception("Error during download of stock data from Yahoo Finance with `yfinance`.")
     return resp


### PR DESCRIPTION
The response from yfinance for a single stock is a flat dataframe. FinQuant is expecting a MultiIndex dataframe with the stock symbol listed for each column. If the returned dataframe from yfinance is not MultiIndex then add the only stock symbol as the MultiIndex. #42 