### PR TITLE
add missing sma import to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ yields
 
 ### Bollinger Band
 ```
-from finquant.moving_average import plot_bollinger_band
+from finquant.moving_average import plot_bollinger_band, sma
 # get stock data for disney
 dis = pf.get_stock("DIS").data.copy(deep=True)
 span=20


### PR DESCRIPTION
The example in the readme file on plotting bollinger band lacks the sma function import. This PR provides a fix.