### PR TITLE
fixed #73.

### DIFF
--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -257,7 +257,7 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio.append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -257,7 +257,9 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = pd.concat(
+            [self.portfolio, stock.investmentinfo.to_frame().T], ignore_index=True
+        )
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe


### PR DESCRIPTION
The "append" method in Pandas is deprecated since version 1.4.0.

It can still be called with the underscore prefix, which allows to easily update the code (and it goes very well with black formatter).

In future versions, it might be necessary to replace "DataFrame.append" with "Pandas.concat".