### PR TITLE
Bugfix/fail example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ yields
 
 ### Bollinger Band
 ```
-from finquant.moving_average import plot_bollinger_band
+from finquant.moving_average import plot_bollinger_band, sma
 # get stock data for disney
 dis = pf.get_stock("DIS").data.copy(deep=True)
 span=20

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -257,7 +257,7 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio.append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -198,7 +198,7 @@ class Portfolio(object):
     def totalinvestment(self, val):
         if val is not None:
             # treat "None" as initialisation
-            if not isinstance(val, (float, int, np.int64)):
+            if not isinstance(val, (float, int, np.floating, np.integer)):
                 raise ValueError("Total investment must be a float or integer.")
             elif val <= 0:
                 raise ValueError(
@@ -257,7 +257,9 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = pd.concat(
+            [self.portfolio, stock.investmentinfo.to_frame().T], ignore_index=True
+        )
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -198,7 +198,7 @@ class Portfolio(object):
     def totalinvestment(self, val):
         if val is not None:
             # treat "None" as initialisation
-            if not isinstance(val, (float, int)):
+            if not isinstance(val, (float, int, np.int64)):
                 raise ValueError("Total investment must be a float or integer.")
             elif val <= 0:
                 raise ValueError(


### PR DESCRIPTION
Fixes #74. The sum() method returns an instance of numpy.int64 if the allocation only contains integers.

An instance of numpy.int64 is not recognized as an instance of int, as they are two different classes.

This causes the error message since the total investment is not recognized as an integer.

Curious: trying with allocations equal to 20^(200), the returned number is an instance of "int" instead of "numpy.int64".