### PR TITLE
Bugfix/deprecation num py

### DIFF
--- a/finquant/monte_carlo.py
+++ b/finquant/monte_carlo.py
@@ -34,7 +34,7 @@ class MonteCarlo(object):
         for i in range(self.num_trials):
             res = fun(**kwargs)
             result.append(res)
-        return np.asarray(result)
+        return np.asarray(result, dtype=object)
 
 
 class MonteCarloOpt(MonteCarlo):

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -257,7 +257,7 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio.append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -198,7 +198,7 @@ class Portfolio(object):
     def totalinvestment(self, val):
         if val is not None:
             # treat "None" as initialisation
-            if not isinstance(val, (float, int, np.int64)):
+            if not isinstance(val, (float, int, np.floating, np.integer)):
                 raise ValueError("Total investment must be a float or integer.")
             elif val <= 0:
                 raise ValueError(
@@ -257,7 +257,9 @@ class Portfolio(object):
         # adding stock to dictionary containing all stocks provided
         self.stocks.update({stock.name: stock})
         # adding information of stock to the portfolio
-        self.portfolio = self.portfolio._append(stock.investmentinfo, ignore_index=True)
+        self.portfolio = pd.concat(
+            [self.portfolio, stock.investmentinfo.to_frame().T], ignore_index=True
+        )
         # setting an appropriate name for the portfolio
         self.portfolio.name = "Allocation of stocks"
         # also add stock data of stock to the dataframe

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -198,7 +198,7 @@ class Portfolio(object):
     def totalinvestment(self, val):
         if val is not None:
             # treat "None" as initialisation
-            if not isinstance(val, (float, int)):
+            if not isinstance(val, (float, int, np.int64)):
                 raise ValueError("Total investment must be a float or integer.")
             elif val <= 0:
                 raise ValueError(


### PR DESCRIPTION
Fixes #72. Creating a numpy ndarray from ragged nested sequences is deprecated.

It is now necessary to specify the additional parameter 'dtype=object'.