### PR TITLE
Fixes #74. The sum() method returns an instance of numpy.int64 if the…

### DIFF
--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -198,7 +198,7 @@ class Portfolio(object):
     def totalinvestment(self, val):
         if val is not None:
             # treat "None" as initialisation
-            if not isinstance(val, (float, int)):
+            if not isinstance(val, (float, int, np.floating, np.integer)):
                 raise ValueError("Total investment must be a float or integer.")
             elif val <= 0:
                 raise ValueError(


### PR DESCRIPTION
… allocation only contains integers.

An instance of numpy.int64 is not recognized as an instance of int, as they are two different classes.

This causes the error message since the total investment is not recognized as an integer.

Curious: trying with allocations equal to 20^(200), the returned number is an instance of "int" instead of "numpy.int64"

I added np.integer and np.floating to the checks