### PR TITLE
Fixes #72. Creating a numpy ndarray from ragged nested sequences is d…

### DIFF
--- a/finquant/monte_carlo.py
+++ b/finquant/monte_carlo.py
@@ -34,7 +34,7 @@ class MonteCarlo(object):
         for i in range(self.num_trials):
             res = fun(**kwargs)
             result.append(res)
-        return np.asarray(result)
+        return np.asarray(result, dtype=object)
 
 
 class MonteCarloOpt(MonteCarlo):


### PR DESCRIPTION
…eprecated.

It is now necessary to specify the additional parameter 'dtype=object'.