### PR TITLE
Feature/beta parameter

### DIFF
--- a/example/Example-Build-Portfolio-from-web.py
+++ b/example/Example-Build-Portfolio-from-web.py
@@ -5,7 +5,7 @@
 
 # # Building a portfolio with data from `quandl`/`yfinance`
 # ## Building a portfolio with `build_portfolio()` by downloading relevant data through `quandl`/`yfinance` with stock names, start and end date and column labels
-# This example only focuses on how to use `build_portfolio()` to get an instance of `Portfolio` by providing minimal information that is passed on to `quandl`/`yfinance`. For a more exhaustive description of this package and example, please try `Example-Analysis` and `Example-Optimisation`.
+# This example only focuses on how to use `build_portfolio()` to get an instance of `Portfolio` by providing a few information that is passed on to `quandl`/`yfinance`. For a more exhaustive description of this package and example, please try `Example-Analysis` and `Example-Optimisation`.
 
 # <codecell>
 
@@ -22,49 +22,50 @@ from finquant.portfolio import build_portfolio
 
 # <codecell>
 
-# To play around yourself with different stocks, here is a short list of companies and their tickers
-# d = {0: {'Name':'WIKI/GOOG', 'Allocation':20},  # Google
-#      1: {'Name':'WIKI/AMZN', 'Allocation':33},  # Amazon
-#      2: {'Name':'WIKI/MSFT', 'Allocation':18},  # Microsoft
-#      3: {'Name':'WIKI/AAPL', 'Allocation':10},  # Apple
-#      4: {'Name':'WIKI/KO', 'Allocation':15},    # Coca-Cola
-#      5: {'Name':'WIKI/XOM', 'Allocation':11},   # Exxon Mobil
-#      6: {'Name':'WIKI/JPM', 'Allocation':21},   # JP Morgan
-#      7: {'Name':'WIKI/DIS', 'Allocation':9},    # Disney
-#      8: {'Name':'WIKI/MCD', 'Allocation':23},   # McDonald's
-#      9: {'Name':'WIKI/WMT', 'Allocation':3},    # Walmart
-#     10: {'Name':'WIKI/YHOO', 'Allocation':7},   # Yahoo
-#     11: {'Name':'WIKI/GS', 'Allocation':9},     # Goldman Sachs
+# To play around yourself with different stocks, here is a short list of companies and their tickers on Yahoo Finance:
+# d = {0: {'Name':'GOOG', 'Allocation':20},  # Google
+#      1: {'Name':'AMZN', 'Allocation':33},  # Amazon
+#      2: {'Name':'MSFT', 'Allocation':18},  # Microsoft
+#      3: {'Name':'AAPL', 'Allocation':10},  # Apple
+#      4: {'Name':'KO', 'Allocation':15},    # Coca-Cola
+#      5: {'Name':'XOM', 'Allocation':11},   # Exxon Mobil
+#      6: {'Name':'JPM', 'Allocation':21},   # JP Morgan
+#      7: {'Name':'DIS', 'Allocation':9},    # Disney
+#      8: {'Name':'MCD', 'Allocation':23},   # McDonald's
+#      9: {'Name':'WMT', 'Allocation':3},    # Walmart
+#     10: {'Name':'GS', 'Allocation':9},     # Goldman Sachs
 #     }
 
 # <codecell>
 
 d = {
-    0: {"Name": "WIKI/GOOG", "Allocation": 20},
-    1: {"Name": "WIKI/AMZN", "Allocation": 10},
-    2: {"Name": "WIKI/MCD", "Allocation": 15},
-    3: {"Name": "WIKI/DIS", "Allocation": 18},
+    0: {"Name": "GOOG", "Allocation": 20},
+    1: {"Name": "AMZN", "Allocation": 10},
+    2: {"Name": "MCD", "Allocation": 15},
+    3: {"Name": "DIS", "Allocation": 18},
 }
-# If you wish to use Yahoo Finance as source, you must remove "WIKI/" from the stock names/tickers
+# If you wish to use `quandl` as source, you must add "WIKI/" at the beginning of stock names/tickers, as "WIKI/GOOG".
 
 pf_allocation = pd.DataFrame.from_dict(d, orient="index")
 
 # <markdowncell>
 
 # ### User friendly interface to quandl/yfinance
-# As mentioned above, in this example `build_portfolio()` is used to build a portfolio by performing a query to `quandl`/`yfinance`.
+# As mentioned above, in this example `build_portfolio()` is used to build a portfolio by performing a query to `quandl`/`yfinance`. We mention that `quandl` will be removed in future versions of `FinQuant` as it is deprecated.
 #
-# To download Google's stock data, `quandl` requires the string `"WIKI/GOOG"`. For simplicity, `FinQuant` facilitates a set of functions under the hood to sort out lots of specific commands/required input for `quandl`/`yfinance`. When using `FinQuant`, the user simply needs to provide a list of stock names/tickers.
-# For example, if using `quandl` as a data source (default), a list of names/tickers as shown below is a valid input for `FinQuant`'s function `build_portfolio(names=names)`:
+# To download Google's stock data, `quandl` requires the string `"WIKI/GOOG"` and `yfinance` the string `"GOOG"`.
+# For simplicity, `FinQuant` facilitates a set of functions under the hood to sort out lots of specific commands/required input for `quandl`/`yfinance`. When using `FinQuant`, the user simply needs to provide a list of stock names/tickers.
+# For example, if using `quandl` as a data source (currently the default option), a list of names/tickers as shown below is a valid input for `FinQuant`'s function `build_portfolio(names=names)`:
 #  * `names = ["WIKI/GOOG", "WIKI/AMZN"]`
 #
 # If using `yfinance` as a data source, `FinQuant`'s function `build_portfolio(names=names)` expects the stock names to be without any leading/trailing string (check Yahoo Finance for correct stock names):
 #  * `names = ["GOOG", "AMZN"]`
 #
-# By default, `FinQuant` uses `quandl` to obtain stock price data. The function `build_portfolio()` can be called with the optional argument `data_api` to use `yfinance` instead:
+# By default, `FinQuant` currently uses `quandl` to obtain stock price data. The function `build_portfolio()` can be called with the optional argument `data_api` to use `yfinance` instead:
 #  * `build_portfolio(names=names, data_api="yfinance")`
 #
-# In the below example we are using the default option, `quandl`.
+# In the below example we are using `yfinance` to download stock data. We specify the start and end date of the stock prices to be downloaded.
+# We also provide the optional parameter `market_index` to download the historical data of a market index. `FinQuant` can use them to calculate the beta parameter, measuring the portfolio's daily volatility compared to the market.
 
 # <codecell>
 
@@ -76,6 +77,10 @@ names = pf_allocation["Name"].values.tolist()
 start_date = datetime.datetime(2015, 1, 1)
 end_date = "2017-12-31"
 
+# the market index used to compare the portfolio to (in this case S&P 500).
+# If the parameter is omitted, no market comparison will be done
+market_index = "^GSPC"
+
 # While quandl/yfinance will download lots of different prices for each stock,
 # e.g. high, low, close, etc, FinQuant will extract the column "Adj. Close" ("Adj Close" if using yfinance).
 
@@ -84,7 +89,8 @@ pf = build_portfolio(
     pf_allocation=pf_allocation,
     start_date=start_date,
     end_date=end_date,
-    data_api="quandl",
+    data_api="yfinance",
+    market_index=market_index,
 )
 
 # <markdowncell>

--- a/example/Example-Build-Portfolio-from-web.py
+++ b/example/Example-Build-Portfolio-from-web.py
@@ -5,7 +5,7 @@
 
 # # Building a portfolio with data from `quandl`/`yfinance`
 # ## Building a portfolio with `build_portfolio()` by downloading relevant data through `quandl`/`yfinance` with stock names, start and end date and column labels
-# This example only focuses on how to use `build_portfolio()` to get an instance of `Portfolio` by providing a few information that is passed on to `quandl`/`yfinance`. For a more exhaustive description of this package and example, please try `Example-Analysis` and `Example-Optimisation`.
+# This example only focuses on how to use `build_portfolio()` to get an instance of `Portfolio` by providing a few items of information that is passed on to `quandl`/`yfinance`. For a more exhaustive description of this package and example, please try `Example-Analysis` and `Example-Optimisation`.
 
 # <codecell>
 

--- a/finquant/market.py
+++ b/finquant/market.py
@@ -1,0 +1,87 @@
+"""This module provides a public class ``Market`` that holds and calculates quantities of a market index"""
+
+import numpy as np
+import pandas as pd
+
+from .returns import historical_mean_return
+from .returns import daily_returns
+
+
+class Market(object):
+    """Object that contains information about a market index.
+    To initialise the object, it requires a name and information about
+    the index given as ``pandas.Series`` data structure.
+    """
+
+    def __init__(self, data: pd.Series) -> None:
+        """
+        :Input:
+         :data: ``pandas.Series`` of market index prices
+        """
+        self.name = data.name
+        self.data = data
+        # compute expected return and volatility of market index
+        self.expected_return = self.comp_expected_return()
+        self.volatility = self.comp_volatility()
+        self.skew = self._comp_skew()
+        self.kurtosis = self._comp_kurtosis()
+        self.daily_returns = self.comp_daily_returns()
+
+    # functions to compute quantities
+    def comp_daily_returns(self) -> pd.Series:
+        """Computes the daily returns (percentage change) of the market index.
+        See ``finance_portfolio.returns.daily_returns``.
+        """
+        return daily_returns(self.data)
+
+    def comp_expected_return(self, freq=252) -> float:
+        """Computes the Expected Return of the market index.
+        See ``finance_portfolio.returns.historical_mean_return``.
+
+        :Input:
+         :freq: ``int`` (default: ``252``), number of trading days, default
+             value corresponds to trading days in a year
+
+        :Output:
+         :expected_return: Expected Return of market index.
+        """
+        return historical_mean_return(self.data, freq=freq)
+
+    def comp_volatility(self, freq=252) -> float:
+        """Computes the Volatility of the market index.
+
+        :Input:
+         :freq: ``int`` (default: ``252``), number of trading days, default
+             value corresponds to trading days in a year
+
+        :Output:
+         :volatility: volatility of market index.
+        """
+        return self.comp_daily_returns().std() * np.sqrt(freq)
+
+    def _comp_skew(self) -> float:
+        """Computes and returns the skewness of the market index."""
+        return self.data.skew()
+
+    def _comp_kurtosis(self) -> float:
+        """Computes and returns the Kurtosis of the market index."""
+        return self.data.kurt()
+
+    def properties(self):
+        """Nicely prints out the properties of the market index:
+        Expected Return, Volatility, Skewness, and Kurtosis.
+        """
+        # nicely printing out information and quantities of market index
+        string = "-" * 50
+        string += "\Market index: {}".format(self.name)
+        string += "\nExpected Return:{:0.3f}".format(self.expected_return)
+        string += "\nVolatility: {:0.3f}".format(self.volatility)
+        string += "\nSkewness: {:0.5f}".format(self.skew)
+        string += "\nKurtosis: {:0.5f}".format(self.kurtosis)
+        string += "-" * 50
+        print(string)
+
+    def __str__(self):
+        # print short description
+        string = "Contains information about " + str(self.name) + "."
+        return string

--- a/finquant/market.py
+++ b/finquant/market.py
@@ -3,8 +3,7 @@
 import numpy as np
 import pandas as pd
 
-from .returns import historical_mean_return
-from .returns import daily_returns
+from finquant.returns import historical_mean_return, daily_returns
 
 
 class Market(object):
@@ -83,5 +82,5 @@ class Market(object):
 
     def __str__(self):
         # print short description
-        string = "Contains information about " + str(self.name) + "."
+        string = "Contains information about market index " + str(self.name) + "."
         return string

--- a/finquant/minimise_fun.py
+++ b/finquant/minimise_fun.py
@@ -7,7 +7,7 @@ from finquant.quants import annualised_portfolio_quantities
 
 
 def portfolio_volatility(weights, mean_returns, cov_matrix):
-    """Calculates the volatility a portfolio
+    """Calculates the volatility of a portfolio
 
     :Input:
      :weights: numpy.ndarray, weights of the stocks in the portfolio

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -1082,7 +1082,7 @@ def build_portfolio(**kwargs):
 
     .. note:: Only the following combinations of inputs are allowed:
 
-     - ``names``, ``pf_allocation`` (optional), ``start_date`` (optional), ``end_date`` (optional), data_api (optional)
+     - ``names``, ``pf_allocation`` (optional), ``start_date`` (optional), ``end_date`` (optional), data_api (optional), ``market_index`` (optional)
      - ``data``, ``pf_allocation`` (optional)
 
      The two different ways this function can be used are useful for:
@@ -1137,7 +1137,7 @@ def build_portfolio(**kwargs):
     # create an empty portfolio
     pf = Portfolio()
 
-    # 1. pf_allocation, names, start_date, end_date, data_api
+    # 1. pf_allocation, names, start_date, end_date, data_api, market_index
     allowed_mandatory_args = ["names"]
     allowed_input_args = [
         "names",

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -18,6 +18,7 @@ and makes the most common quantitative calculations, such as:
 - Expected (annualised) Return,
 - Volatility,
 - Sharpe Ratio,
+- Beta parameter (optional),
 - skewness of the portfolio's stocks,
 - Kurtosis of the portfolio's stocks,
 - the portfolio's covariance matrix.
@@ -136,6 +137,14 @@ class Portfolio(object):
             self.__risk_free_rate = val
             # now that this changed, update other quantities
             self._update()
+
+    def set_market_index(self, index: Market) -> None:
+        """Adds an index market ``index`` to the portfolio.
+
+        :Input:
+         :index: an object of ``Index``
+        """
+        self.market_index = index
 
     def add_stock(self, stock):
         """Adds a stock of type ``Stock`` to the portfolio. Each time ``add_stock``
@@ -1001,6 +1010,7 @@ def _build_portfolio_from_df(
     # building portfolio:
     pf = Portfolio()
     if market_data is not None and not market_data.empty:
+        # extract only "Adjusted Close" price column from market data
         market_data = _get_index_adj_clos_pr(market_data)
         # set market index of portfolio
         pf.set_market_index(Market(data=market_data))

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -87,7 +87,7 @@ class Portfolio(object):
         # Monte Carlo optimisations
         self.ef = None
         self.mc = None
-        # istance variable for Market class
+        # instance variable for Market class
         self.market_index = None
         # dataframe containing beta values of stocks
         self.beta_stocks = pd.DataFrame(index=["beta"])

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -139,7 +139,7 @@ class Portfolio(object):
             self._update()
 
     @property
-    def market_index(self) -> Optional[Market]:
+    def market_index(self) -> Market:
         return self.__market_index
 
     @market_index.setter

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -139,10 +139,10 @@ class Portfolio(object):
             self._update()
 
     def set_market_index(self, index: Market) -> None:
-        """Adds an index market ``index`` to the portfolio.
+        """Set the market index to the portfolio.
 
         :Input:
-         :index: an object of ``Index``
+         :index: an object of ``Market`` class.
         """
         self.market_index = index
 

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -1021,7 +1021,7 @@ def _build_portfolio_from_df(
         # extract only "Adjusted Close" price column from market data
         market_data = _get_index_adj_clos_pr(market_data)
         # set market index of portfolio
-        pf.set_market_index(Market(data=market_data))
+        pf.market_index = Market(data=market_data)
     for i in range(len(pf_allocation)):
         # get name of stock
         name = pf_allocation.loc[i].Name

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -868,7 +868,6 @@ def _build_portfolio_from_api(
          obtain stock prices, if data is not provided by the user. Valid values:
          - ``quandl`` (Python package/API to `Quandl`)
          - ``yfinance`` (Python package formerly known as ``fix-yahoo-finance``)
-
      :market_index: (optional) ``string`` (default: ``None``) which determines the
          market index to be used for the computation of the beta parameter of the stocks.
 

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -138,13 +138,17 @@ class Portfolio(object):
             # now that this changed, update other quantities
             self._update()
 
-    def set_market_index(self, index: Market) -> None:
+    @property
+    def market_index(self) -> Optional[Market]:
+        return self.__market_index
+
+    @market_index.setter
+    def market_index(self, index: Market) -> None:
         """Set the market index to the portfolio.
 
-        :Input:
-         :index: an object of ``Market`` class.
+        :param index: An object of the ``Market`` class.
         """
-        self.market_index = index
+        self.__market_index = index
 
     def add_stock(self, stock):
         """Adds a stock of type ``Stock`` to the portfolio. Each time ``add_stock``

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -652,6 +652,11 @@ class Portfolio(object):
         string += "-" * 70
         print(string)
 
+    def __str__(self):
+        # print short description
+        string = "Contains information about a portfolio."
+        return string
+
 
 def _correct_quandl_request_stock_name(names):
     """If given input argument is of type string,

--- a/finquant/returns.py
+++ b/finquant/returns.py
@@ -55,13 +55,13 @@ def historical_mean_return(data, freq=252):
     """Returns the mean return based on historical stock price data.
 
     :Input:
-     :data: ``pandas.DataFrame`` with daily stock prices
+     :data: ``pandas.DataFrame`` or ``pandas.Series`` with daily stock prices
      :freq: ``int`` (default= ``252``), number of trading days, default
              value corresponds to trading days in a year
 
     :Output:
-     :ret: a ``pandas.DataFrame`` of historical mean Returns.
+     :ret: a ``pandas.Series`` or ``numpy.float`` of historical mean Returns.
     """
-    if not isinstance(data, pd.DataFrame):
-        raise ValueError("data must be a pandas.DataFrame")
+    if not isinstance(data, (pd.DataFrame, pd.Series)):
+        raise ValueError("data must be a pandas.DataFrame or pandas.Series")
     return daily_returns(data).mean() * freq

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -4,6 +4,7 @@ Every time a new instance of ``Stock`` is added to ``Portfolio``, the quantities
 """
 
 import numpy as np
+import pandas as pd
 from finquant.returns import historical_mean_return
 from finquant.returns import daily_returns
 
@@ -48,6 +49,8 @@ class Stock(object):
         self.volatility = self.comp_volatility()
         self.skew = self._comp_skew()
         self.kurtosis = self._comp_kurtosis()
+        # beta parameter of stock (CAPM)
+        self.beta = None
 
     # functions to compute quantities
     def comp_daily_returns(self):
@@ -87,6 +90,24 @@ class Stock(object):
     def _comp_kurtosis(self):
         """Computes and returns the Kurtosis of the stock."""
         return self.data.kurt().values[0]
+
+    def comp_beta(self, market_daily_returns: pd.Series) -> float:
+        """Compute and return the Beta parameter of the stock.
+
+        :Input:
+         :market_daily_returns: ``pd.Series``, daily returns of the market
+
+        :Output:
+         :sharpe: ``float``, the Beta parameter of the stock
+        """
+        cov_mat = np.cov(
+            self.comp_daily_returns()[self.name],
+            market_daily_returns.to_frame()[market_daily_returns.name],
+        )
+
+        beta = cov_mat[0, 1] / cov_mat[1, 1]
+        self.beta = beta
+        return beta
 
     def properties(self):
         """Nicely prints out the properties of the stock: Expected Return,

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -7,7 +7,6 @@ import pandas as pd
 import yfinance
 import pytest
 from finquant.portfolio import build_portfolio
-from finquant.stock import Stock
 from finquant.market import Market
 
 d = {

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -1,0 +1,42 @@
+###################
+# tests for Market #
+###################
+
+import numpy as np
+import pandas as pd
+import yfinance
+import pytest
+from finquant.portfolio import build_portfolio
+from finquant.stock import Stock
+from finquant.market import Market
+
+d = {
+    0: {"Name": "GOOG", "Allocation": 20},
+    1: {"Name": "AMZN", "Allocation": 10},
+    2: {"Name": "MCD", "Allocation": 15},
+    3: {"Name": "DIS", "Allocation": 18},
+    4: {"Name": "TSLA", "Allocation": 48},
+}
+
+
+pf_allocation = pd.DataFrame.from_dict(d, orient="index")
+
+names_yf = pf_allocation["Name"].values.tolist()
+
+# dates can be set as datetime or string, as shown below:
+start_date = "2018-01-01"
+end_date = "2023-01-01"
+
+
+def test_Market():
+    pf = build_portfolio(
+        names=names_yf,
+        pf_allocation=pf_allocation,
+        start_date=start_date,
+        end_date=end_date,
+        data_api="yfinance",
+        market_index="^GSPC",
+    )
+    assert isinstance(pf.market_index, Market)
+    assert pf.market_index.name == "^GSPC"
+    assert pf.beta is not None


### PR DESCRIPTION
Adding computation of the beta parameter for the portfolio. In the Capital Asset Pricing Model (CAPM), the beta parameter defines how risky the portfolio is compared to the market. 

Important: I could not run the old tests due to the usual _quandl_ error (although I obtained my API key). I still don't know what's happening, but I'm working on it. The old tests should be run as a sanity check before merging the pull request.

However, the additional feature is written so that all the previous codes and tests should still work: suppose the argument "market_index" is not explicitly passed to the "build_portfolio" function. In that case, the Market class instance is not created, and the beta parameter of the portfolio is not computed or printed in properties.

@fmilthaler if there's something you would like me to change, please tell me.

All the best