### PR TITLE
Refactor/stocks data as pdseries

### DIFF
--- a/finquant/efficient_frontier.py
+++ b/finquant/efficient_frontier.py
@@ -348,8 +348,8 @@ class EfficientFrontier(object):
     def plot_optimal_portfolios(self):
         """Plots markers of the optimised portfolios for
 
-         - minimum Volatility, and
-         - maximum Sharpe Ratio.
+        - minimum Volatility, and
+        - maximum Sharpe Ratio.
         """
         # compute optimal portfolios
         min_vol_weights = self.minimum_volatility(save_weights=False)

--- a/finquant/market.py
+++ b/finquant/market.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pandas as pd
 
-from finquant.returns import historical_mean_return, daily_returns
+from finquant.returns import daily_returns, historical_mean_return
 
 
 class Market(object):

--- a/finquant/moving_average.py
+++ b/finquant/moving_average.py
@@ -13,7 +13,9 @@ import pandas as pd
 from typing import Callable, List
 
 
-def compute_ma(data, fun: Callable, spans: List[int], plot: bool = True) -> pd.DataFrame:
+def compute_ma(
+    data, fun: Callable, spans: List[int], plot: bool = True
+) -> pd.DataFrame:
     """Computes a band of moving averages (sma or ema, depends on the input argument
     `fun`) for a number of different time windows. If `plot` is `True`, it also
     computes and sets markers for buy/sell signals based on crossovers of the Moving
@@ -33,7 +35,9 @@ def compute_ma(data, fun: Callable, spans: List[int], plot: bool = True) -> pd.D
      :ma: pandas.DataFrame with moving averages of given data.
     """
     if not isinstance(data, (pd.Series, pd.DataFrame)):
-        raise ValueError("data is expected to be of type pandas.Series or pandas.DataFrame")
+        raise ValueError(
+            "data is expected to be of type pandas.Series or pandas.DataFrame"
+        )
     ma = data.copy(deep=True)
     # converting data to pd.DataFrame if it is a pd.Series (for subsequent function calls):
     if isinstance(ma, pd.Series):
@@ -162,7 +166,9 @@ def plot_bollinger_band(data, fun: Callable, span: int = 100) -> None:
          the average is computed
     """
     if not isinstance(data, (pd.Series, pd.DataFrame)):
-        raise ValueError("data is expected to be of type pandas.Series or pandas.DataFrame")
+        raise ValueError(
+            "data is expected to be of type pandas.Series or pandas.DataFrame"
+        )
     if isinstance(data, pd.DataFrame) and not len(data.columns.values) == 1:
         raise ValueError("data is expected to have only one column.")
     if not isinstance(span, int):

--- a/finquant/moving_average.py
+++ b/finquant/moving_average.py
@@ -7,12 +7,13 @@
 """
 
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
+from typing import Callable, List
 
 
-def compute_ma(data, fun, spans, plot=True):
+def compute_ma(data, fun: Callable, spans: List[int], plot: bool = True) -> pd.DataFrame:
     """Computes a band of moving averages (sma or ema, depends on the input argument
     `fun`) for a number of different time windows. If `plot` is `True`, it also
     computes and sets markers for buy/sell signals based on crossovers of the Moving
@@ -25,7 +26,7 @@ def compute_ma(data, fun, spans, plot=True):
          ema (exponential).
      :spans: list of integers, time windows to compute the Moving Average on.
      :plot: boolean (default: True), whether to plot the moving averages
-         and buy/sell signales based on crossovers of shortest and longest
+         and buy/sell signals based on crossovers of shortest and longest
          moving average.
 
     :Output:
@@ -86,14 +87,14 @@ def compute_ma(data, fun, spans, plot=True):
     return ma
 
 
-def sma(data, span=100):
+def sma(data: pd.DataFrame, span: int = 100) -> pd.DataFrame:
     """Computes and returns the simple moving average.
 
     Note: the moving average is computed on all columns.
 
     :Input:
      :data: pandas.DataFrame with stock prices in columns
-     :span: int (defaul: 100), number of days/values over which
+     :span: int (default: 100), number of days/values over which
          the average is computed
 
     :Output:
@@ -102,14 +103,14 @@ def sma(data, span=100):
     return data.rolling(window=span, center=False).mean()
 
 
-def ema(data, span=100):
+def ema(data: pd.DataFrame, span: int = 100) -> pd.DataFrame:
     """Computes and returns the exponential moving average.
 
     Note: the moving average is computed on all columns.
 
     :Input:
      :data: pandas.DataFrame with stock prices in columns
-     :span: int (defaul: 100), number of days/values over which
+     :span: int (default: 100), number of days/values over which
          the average is computed
 
     :Output:
@@ -118,13 +119,13 @@ def ema(data, span=100):
     return data.ewm(span=span, adjust=False, min_periods=span).mean()
 
 
-def sma_std(data, span=100):
+def sma_std(data: pd.DataFrame, span: int = 100) -> pd.DataFrame:
     """Computes and returns the standard deviation of the simple moving
     average.
 
     :Input:
      :data: pandas.DataFrame with stock prices in columns
-     :span: int (defaul: 100), number of days/values over which
+     :span: int (default: 100), number of days/values over which
          the average is computed
 
     :Output:
@@ -134,13 +135,13 @@ def sma_std(data, span=100):
     return data.rolling(window=span, center=False).std()
 
 
-def ema_std(data, span=100):
+def ema_std(data: pd.DataFrame, span: int = 100) -> pd.DataFrame:
     """Computes and returns the standard deviation of the exponential
     moving average.
 
     :Input:
      :data: pandas.DataFrame with stock prices in columns
-     :span: int (defaul: 100), number of days/values over which
+     :span: int (default: 100), number of days/values over which
          the average is computed
 
     :Output:
@@ -150,14 +151,14 @@ def ema_std(data, span=100):
     return data.ewm(span=span, adjust=False, min_periods=span).std()
 
 
-def plot_bollinger_band(data, fun, span):
+def plot_bollinger_band(data, fun: Callable, span: int = 100) -> None:
     """Computes and visualises a Bolling Band.
 
     :Input:
      :data: pandas.Series or pandas.DataFrame with stock prices in columns
      :fun: function that computes a moving average, e.g. sma (simple) or
          ema (exponential).
-     :span: int (defaul: 100), number of days/values over which
+     :span: int (default: 100), number of days/values over which
          the average is computed
     """
     if not isinstance(data, (pd.Series, pd.DataFrame)):

--- a/finquant/moving_average.py
+++ b/finquant/moving_average.py
@@ -19,7 +19,8 @@ def compute_ma(data, fun, spans, plot=True):
     Averages with the shortest/longest spans.
 
     :Input:
-     :data: pandas.DataFrame with stock prices, only one column is expected.
+     :data: pandas.DataFrame, or pandas.Series, with stock prices
+         (if pandas.DataFrame: only one column is expected)
      :fun: function that computes a moving average, e.g. sma (simple) or
          ema (exponential).
      :spans: list of integers, time windows to compute the Moving Average on.
@@ -30,10 +31,13 @@ def compute_ma(data, fun, spans, plot=True):
     :Output:
      :ma: pandas.DataFrame with moving averages of given data.
     """
-    if not isinstance(data, pd.DataFrame):
-        raise ValueError("data must be of type pandas.DataFrame")
-    # compute moving averages
+    if not isinstance(data, (pd.Series, pd.DataFrame)):
+        raise ValueError("data is expected to be of type pandas.Series or pandas.DataFrame")
     ma = data.copy(deep=True)
+    # converting data to pd.DataFrame if it is a pd.Series (for subsequent function calls):
+    if isinstance(ma, pd.Series):
+        ma = ma.to_frame()
+    # compute moving averages
     for span in spans:
         ma[str(span) + "d"] = fun(data, span=span)
     if plot:
@@ -150,18 +154,21 @@ def plot_bollinger_band(data, fun, span):
     """Computes and visualises a Bolling Band.
 
     :Input:
-     :data: pandas.DataFrame with stock prices in columns
+     :data: pandas.Series or pandas.DataFrame with stock prices in columns
      :fun: function that computes a moving average, e.g. sma (simple) or
          ema (exponential).
      :span: int (defaul: 100), number of days/values over which
          the average is computed
     """
-    if not isinstance(data, pd.DataFrame):
-        raise ValueError("data is expected to be a pandas.DataFrame")
-    if not len(data.columns.values) == 1:
+    if not isinstance(data, (pd.Series, pd.DataFrame)):
+        raise ValueError("data is expected to be of type pandas.Series or pandas.DataFrame")
+    if isinstance(data, pd.DataFrame) and not len(data.columns.values) == 1:
         raise ValueError("data is expected to have only one column.")
     if not isinstance(span, int):
         raise ValueError("span must be an integer.")
+    # converting data to pd.DataFrame if it is a pd.Series (for subsequent function calls):
+    if isinstance(data, pd.Series):
+        data = data.to_frame()
     # compute moving average
     ma = compute_ma(data, fun, [span], plot=False)
     # create dataframes for bollinger band object and standard

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -185,7 +185,9 @@ class Portfolio(object):
 
     def _add_stock_data(self, stock: Stock) -> None:
         # insert given data into portfolio stocks dataframe:
-        self.data.insert(loc=len(self.data.columns), column=stock.name, value=stock.data)
+        self.data.insert(
+            loc=len(self.data.columns), column=stock.name, value=stock.data
+        )
         # set index correctly
         self.data.set_index(stock.data.index.values, inplace=True)
         # set index name:

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -5,8 +5,7 @@ Every time a new instance of ``Stock`` is added to ``Portfolio``, the quantities
 
 import numpy as np
 import pandas as pd
-from finquant.returns import historical_mean_return
-from finquant.returns import daily_returns
+from finquant.returns import daily_returns, historical_mean_return
 
 
 class Stock(object):

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -5,6 +5,7 @@ Every time a new instance of ``Stock`` is added to ``Portfolio``, the quantities
 
 import numpy as np
 import pandas as pd
+
 from finquant.returns import daily_returns, historical_mean_return
 
 
@@ -34,7 +35,7 @@ class Stock(object):
     data in additional columns.
     """
 
-    def __init__(self, investmentinfo, data):
+    def __init__(self, investmentinfo: pd.DataFrame, data: pd.Series):
         """
         :Input:
          :investmentinfo: ``pandas.DataFrame`` of investment information
@@ -84,11 +85,11 @@ class Stock(object):
 
     def _comp_skew(self):
         """Computes and returns the skewness of the stock."""
-        return self.data.skew().values[0]
+        return self.data.skew()
 
     def _comp_kurtosis(self):
         """Computes and returns the Kurtosis of the stock."""
-        return self.data.kurt().values[0]
+        return self.data.kurt()
 
     def comp_beta(self, market_daily_returns: pd.Series) -> float:
         """Compute and return the Beta parameter of the stock.
@@ -100,7 +101,7 @@ class Stock(object):
          :sharpe: ``float``, the Beta parameter of the stock
         """
         cov_mat = np.cov(
-            self.comp_daily_returns()[self.name],
+            self.comp_daily_returns(),
             market_daily_returns.to_frame()[market_daily_returns.name],
         )
 
@@ -116,8 +117,8 @@ class Stock(object):
         # nicely printing out information and quantities of the stock
         string = "-" * 50
         string += "\nStock: {}".format(self.name)
-        string += "\nExpected Return:{:0.3f}".format(self.expected_return.values[0])
-        string += "\nVolatility: {:0.3f}".format(self.volatility.values[0])
+        string += "\nExpected Return: {:0.3f}".format(self.expected_return)
+        string += "\nVolatility: {:0.3f}".format(self.volatility)
         string += "\nSkewness: {:0.5f}".format(self.skew)
         string += "\nKurtosis: {:0.5f}".format(self.kurtosis)
         string += "\nInformation:"


### PR DESCRIPTION
Refactoring `data` in class `Stock`. Previously this was of type `pandas.DataFrame`, but since this is data for only one stock, and FinQuant always considers only one price ('Adj. Closing Price') per stock, it makes more sense for `Stock.data` to be of type `pandas.Series`.
This closes #91