### PR TITLE
Introducing the R-squared coefficient and Treynor Ratio for a financial portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://img.shields.io/github/stars/fmilthaler/FinQuant.svg?style=social&label=Star" alt='pypi'>
   </a>
   <a href="https://pypi.org/project/FinQuant">
-    <img src="https://img.shields.io/badge/pypi-v0.6.2-brightgreen.svg?style=popout" alt='pypi'>
+    <img src="https://img.shields.io/badge/pypi-v0.7.0-brightgreen.svg?style=popout" alt='pypi'>
   </a>
   <a href="https://github.com/fmilthaler/FinQuant">
     <img src="https://github.com/fmilthaler/finquant/actions/workflows/pytest.yml/badge.svg?branch=master" alt='GitHub Actions'>

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ look at the examples provided in `./example`.
  - Value at Risk, 
  - Sharpe Ratio,
  - Sortino Ratio,
+ - Treynor Ratio,
  - Beta parameter,
  - R squared coefficient.
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ As it is common for open-source projects, there are several ways to get hold of 
  - quandl>=3.4.5
  - yfinance>=0.1.43
  - scipy>=1.2.0
+ - scikit-learn>=1.3.0
 
 ### From PyPI
 *FinQuant* can be obtained from PyPI
@@ -253,7 +254,8 @@ look at the examples provided in `./example`.
  - Value at Risk, 
  - Sharpe Ratio,
  - Sortino Ratio,
- - Beta parameter.
+ - Beta parameter,
+ - R squared coefficient.
 
 It also shows how to extract individual stocks from the given portfolio. Moreover it shows how to compute and visualise:
  - the different Returns provided by the module `finquant.returns`,

--- a/README.tex.md
+++ b/README.tex.md
@@ -7,7 +7,7 @@
     <img src="https://img.shields.io/github/stars/fmilthaler/FinQuant.svg?style=social&label=Star" alt='pypi'>
   </a>
   <a href="https://pypi.org/project/FinQuant">
-    <img src="https://img.shields.io/badge/pypi-v0.6.2-brightgreen.svg?style=popout" alt='pypi'>
+    <img src="https://img.shields.io/badge/pypi-v0.7.0-brightgreen.svg?style=popout" alt='pypi'>
   </a>
   <a href="https://github.com/fmilthaler/FinQuant">
     <img src="https://github.com/fmilthaler/finquant/actions/workflows/pytest.yml/badge.svg?branch=master" alt='GitHub Actions'>

--- a/README.tex.md
+++ b/README.tex.md
@@ -254,6 +254,7 @@ look at the examples provided in `./example`.
  - Value at Risk, 
  - Sharpe Ratio,
  - Sortino Ratio,
+ - Treynor Ratio,
  - Beta parameter,
  - R squared coefficient.
 

--- a/README.tex.md
+++ b/README.tex.md
@@ -169,6 +169,7 @@ As it is common for open-source projects, there are several ways to get hold of 
  - quandl>=3.4.5
  - yfinance>=0.1.43
  - scipy>=1.2.0
+ - scikit-learn>=1.3.0
 
 ### From PyPI
 *FinQuant* can be obtained from PyPI
@@ -253,7 +254,8 @@ look at the examples provided in `./example`.
  - Value at Risk, 
  - Sharpe Ratio,
  - Sortino Ratio,
- - Beta parameter.
+ - Beta parameter,
+ - R squared coefficient.
 
 It also shows how to extract individual stocks from the given portfolio. Moreover it shows how to compute and visualise:
  - the different Returns provided by the module `finquant.returns`,

--- a/example/Example-Build-Portfolio-from-web.py
+++ b/example/Example-Build-Portfolio-from-web.py
@@ -67,7 +67,7 @@ pf_allocation = pd.DataFrame.from_dict(d, orient="index")
 #
 # In the below example we are using `yfinance` to download stock data. We specify the start and end date of the stock prices to be downloaded.
 # We also provide the optional parameter `market_index` to download the historical data of a market index.
-# `FinQuant` can use them to calculate the beta parameter and R squared coefficient, measuring the portfolio's daily volatility and relationship compared to the market.
+# `FinQuant` can use them to calculate the Treynor Ratio, beta parameter, and R squared coefficient, measuring the portfolio's daily volatility compared to the market.
 
 # <codecell>
 

--- a/example/Example-Build-Portfolio-from-web.py
+++ b/example/Example-Build-Portfolio-from-web.py
@@ -66,7 +66,7 @@ pf_allocation = pd.DataFrame.from_dict(d, orient="index")
 #  * `build_portfolio(names=names, data_api="yfinance")`
 #
 # In the below example we are using `yfinance` to download stock data. We specify the start and end date of the stock prices to be downloaded.
-# We also provide the optional parameter `market_index` to download the historical data of a market index. 
+# We also provide the optional parameter `market_index` to download the historical data of a market index.
 # `FinQuant` can use them to calculate the beta parameter and R squared coefficient, measuring the portfolio's daily volatility and relationship compared to the market.
 
 # <codecell>

--- a/example/Example-Build-Portfolio-from-web.py
+++ b/example/Example-Build-Portfolio-from-web.py
@@ -66,7 +66,8 @@ pf_allocation = pd.DataFrame.from_dict(d, orient="index")
 #  * `build_portfolio(names=names, data_api="yfinance")`
 #
 # In the below example we are using `yfinance` to download stock data. We specify the start and end date of the stock prices to be downloaded.
-# We also provide the optional parameter `market_index` to download the historical data of a market index. `FinQuant` can use them to calculate the beta parameter, measuring the portfolio's daily volatility compared to the market.
+# We also provide the optional parameter `market_index` to download the historical data of a market index. 
+# `FinQuant` can use them to calculate the beta parameter and R squared coefficient, measuring the portfolio's daily volatility and relationship compared to the market.
 
 # <codecell>
 

--- a/finquant/data_types.py
+++ b/finquant/data_types.py
@@ -67,6 +67,7 @@ LIST_DICT_KEYS = Union[ARRAY_OR_LIST[ELEMENT_TYPE], KeysView[ELEMENT_TYPE]]
 
 # Numeric types
 FLOAT = Union[np.floating, float]
+FLOAT_OPTIONAL = Union[np.floating, float, None]
 INT = Union[np.integer, int]
 NUMERIC = Union[INT, FLOAT]
 

--- a/finquant/data_types.py
+++ b/finquant/data_types.py
@@ -67,7 +67,7 @@ LIST_DICT_KEYS = Union[ARRAY_OR_LIST[ELEMENT_TYPE], KeysView[ELEMENT_TYPE]]
 
 # Numeric types
 FLOAT = Union[np.floating, float]
-FLOAT_OPTIONAL = Union[np.floating, float, None]
+FLOAT_OPTIONAL = Union[FLOAT, None]
 INT = Union[np.integer, int]
 NUMERIC = Union[INT, FLOAT]
 

--- a/finquant/data_types.py
+++ b/finquant/data_types.py
@@ -67,7 +67,6 @@ LIST_DICT_KEYS = Union[ARRAY_OR_LIST[ELEMENT_TYPE], KeysView[ELEMENT_TYPE]]
 
 # Numeric types
 FLOAT = Union[np.floating, float]
-FLOAT_OPTIONAL = Union[FLOAT, None]
 INT = Union[np.integer, int]
 NUMERIC = Union[INT, FLOAT]
 

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -1031,7 +1031,7 @@ def _build_portfolio_from_api(
         if data is not provided by the user. Valid values:
          - ``quandl`` (Python package/API to `Quandl`)
          - ``yfinance`` (Python package formerly known as ``fix-yahoo-finance``)
-    :param market_index: (optional, default: ``None``) A string which determines the market index 
+    :param market_index: (optional, default: ``None``) A string which determines the market index
         to be used for the computation of the beta parameter and the R squared of the stocks
 
     :return: Instance of Portfolio which contains all the information requested by the user.

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -485,6 +485,7 @@ class Portfolio:
     def comp_rsquared(self) -> Optional[FLOAT]:
         """Compute and return the R squared coefficient of the portfolio.
 
+        :rtype: :py:data:`~.finquant.data_types.FLOAT`
         :return: R squared coefficient of the portfolio
         """
 

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -511,14 +511,14 @@ class Portfolio:
             self.expected_return, self.downside_risk, self.risk_free_rate
         )
 
-    def comp_treynor(self) -> FLOAT:
+    def comp_treynor(self) -> Optional[FLOAT]:
         """Compute and return the Treynor Ratio of the portfolio.
 
         :type freq: :py:data:`~.finquant.data_types.FLOAT`
         :return: The Treynor Ratio of the portfolio.
         """
         # compute the Treynor Ratio of the portfolio
-        treynor: FLOAT = treynor_ratio(
+        treynor: Optional[FLOAT] = treynor_ratio(
             self.expected_return, self.beta, self.risk_free_rate
         )
         self.treynor = treynor

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -514,7 +514,7 @@ class Portfolio:
     def comp_treynor(self) -> Optional[FLOAT]:
         """Compute and return the Treynor Ratio of the portfolio.
 
-        :type freq: :py:data:`~.finquant.data_types.FLOAT`
+        :rtype: :py:data:`~.finquant.data_types.FLOAT`
         :return: The Treynor Ratio of the portfolio.
         """
         # compute the Treynor Ratio of the portfolio

--- a/finquant/portfolio.py
+++ b/finquant/portfolio.py
@@ -786,7 +786,7 @@ class Portfolio:
             - Confidence level of VaR,
             - Sharpe Ratio,
             - Sortino Ratio,
-            - Treynor Ratio (optional),            
+            - Treynor Ratio (optional),
             - Beta (optional),
             - R squared (optional),
             - skewness,

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -14,7 +14,6 @@ from finquant.data_types import (
     ARRAY_OR_DATAFRAME,
     ARRAY_OR_SERIES,
     FLOAT,
-    FLOAT_OPTIONAL,
     INT,
     NUMERIC,
 )

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -115,6 +115,34 @@ def sortino_ratio(
         return (exp_return - risk_free_rate) / float(downs_risk)
 
 
+def treynor_ratio(
+    exp_return: FLOAT, beta: FLOAT, risk_free_rate: FLOAT = 0.005
+) -> FLOAT:
+    """Computes the Treynor Ratio.
+
+    :param exp_return: Expected Return of a portfolio
+    :type exp_return: :py:data:`~.finquant.data_types.FLOAT`
+
+    :param beta: Beta parameter of a portfolio
+    :type beta: :py:data:`~.finquant.data_types.FLOAT`
+
+    :param risk_free_rate: Risk free rate
+    :type risk_free_rate: :py:data:`~.finquant.data_types.FLOAT`, default: 0.005
+
+    :rtype: :py:data:`~.finquant.data_types.FLOAT`
+    :return: Treynor Ratio as a floating point number:
+        ``(exp_return - risk_free_rate) / float(beta)``
+    """
+    # Type validations:
+    type_validation(
+        expected_return=exp_return,
+        beta_parameter=beta,
+        risk_free_rate=risk_free_rate,
+    )
+    res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / float(beta)
+    return res_treynor_ratio
+
+
 def downside_risk(
     data: pd.DataFrame, weights: ARRAY_OR_SERIES[FLOAT], risk_free_rate: FLOAT = 0.005
 ) -> FLOAT:

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -4,7 +4,7 @@ weighted standard deviation (volatility), and the Sharpe ratio.
 """
 
 
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import numpy as np
 import pandas as pd

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -146,8 +146,7 @@ def treynor_ratio(
         beta_parameter=beta,
         risk_free_rate=risk_free_rate,
     )
-    res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / float(beta)
-    return res_treynor_ratio
+    return (exp_return - risk_free_rate) / float(beta)
 
 
 def downside_risk(

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -4,7 +4,7 @@ weighted standard deviation (volatility), and the Sharpe ratio.
 """
 
 
-from typing import Tuple
+from typing import Tuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -123,8 +123,8 @@ def sortino_ratio(
 
 
 def treynor_ratio(
-    exp_return: FLOAT, beta: FLOAT_OPTIONAL, risk_free_rate: FLOAT = 0.005
-) -> FLOAT_OPTIONAL:
+    exp_return: FLOAT, beta: Optional[FLOAT], risk_free_rate: FLOAT = 0.005
+) -> Optional[FLOAT]:
     """Computes the Treynor Ratio.
 
     :param exp_return: Expected Return of a portfolio

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -10,13 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
-from finquant.data_types import (
-    ARRAY_OR_DATAFRAME,
-    ARRAY_OR_SERIES,
-    FLOAT,
-    INT,
-    NUMERIC,
-)
+from finquant.data_types import ARRAY_OR_DATAFRAME, ARRAY_OR_SERIES, FLOAT, INT, NUMERIC
 from finquant.returns import weighted_mean_daily_returns
 from finquant.type_utilities import type_validation
 

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -10,7 +10,14 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
-from finquant.data_types import ARRAY_OR_DATAFRAME, ARRAY_OR_SERIES, FLOAT, INT, NUMERIC
+from finquant.data_types import (
+    ARRAY_OR_DATAFRAME,
+    ARRAY_OR_SERIES,
+    FLOAT,
+    FLOAT_OPTIONAL,
+    INT,
+    NUMERIC,
+)
 from finquant.returns import weighted_mean_daily_returns
 from finquant.type_utilities import type_validation
 
@@ -116,7 +123,7 @@ def sortino_ratio(
 
 
 def treynor_ratio(
-    exp_return: FLOAT, beta: FLOAT, risk_free_rate: FLOAT = 0.005
+    exp_return: FLOAT, beta: FLOAT_OPTIONAL, risk_free_rate: FLOAT = 0.005
 ) -> FLOAT:
     """Computes the Treynor Ratio.
 

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -146,8 +146,11 @@ def treynor_ratio(
         beta_parameter=beta,
         risk_free_rate=risk_free_rate,
     )
-    res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / beta
-    return res_treynor_ratio
+    if beta is None:
+        return np.nan
+    else:
+        res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / beta
+        return res_treynor_ratio
 
 
 def downside_risk(

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -146,7 +146,8 @@ def treynor_ratio(
         beta_parameter=beta,
         risk_free_rate=risk_free_rate,
     )
-    return (exp_return - risk_free_rate) / float(beta)
+    res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / beta
+    return res_treynor_ratio
 
 
 def downside_risk(

--- a/finquant/quants.py
+++ b/finquant/quants.py
@@ -124,7 +124,7 @@ def sortino_ratio(
 
 def treynor_ratio(
     exp_return: FLOAT, beta: FLOAT_OPTIONAL, risk_free_rate: FLOAT = 0.005
-) -> FLOAT:
+) -> FLOAT_OPTIONAL:
     """Computes the Treynor Ratio.
 
     :param exp_return: Expected Return of a portfolio
@@ -138,7 +138,7 @@ def treynor_ratio(
 
     :rtype: :py:data:`~.finquant.data_types.FLOAT`
     :return: Treynor Ratio as a floating point number:
-        ``(exp_return - risk_free_rate) / float(beta)``
+        ``(exp_return - risk_free_rate) / beta``
     """
     # Type validations:
     type_validation(
@@ -147,7 +147,7 @@ def treynor_ratio(
         risk_free_rate=risk_free_rate,
     )
     if beta is None:
-        return np.nan
+        return None
     else:
         res_treynor_ratio: FLOAT = (exp_return - risk_free_rate) / beta
         return res_treynor_ratio

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -16,7 +16,7 @@ To initialize an instance of ``Stock``, it requires the following information:
 
 The ``Stock`` class computes various quantities related to the stock or fund, such as expected return,
 volatility, skewness, and kurtosis. It also provides functionality to calculate the beta parameter
-of the stock using the CAPM (Capital Asset Pricing Model).
+using the CAPM (Capital Asset Pricing Model) and the R squared value of the stock .
 
 The ``Stock`` class inherits from the ``Asset`` class in ``finquant.asset``, which provides common
 functionality and attributes for financial assets.
@@ -32,6 +32,8 @@ from finquant.asset import Asset
 from finquant.data_types import FLOAT
 from finquant.type_utilities import type_validation
 
+from sklearn.metrics import r2_score
+
 
 class Stock(Asset):
     """Class that contains information about a stock/fund.
@@ -44,14 +46,15 @@ class Stock(Asset):
     It requires investment information and historical price data for the stock to initialize an instance.
 
     In addition to the attributes inherited from the ``Asset`` class, the ``Stock`` class provides
-    a method to compute the beta parameter specific to stocks in a portfolio when compared to
-    the market index.
+    a method to compute the beta parameter and one to compute the R squared coefficient
+    specific to stocks in a portfolio when compared to the market index.
 
     """
 
     # Attributes:
     investmentinfo: pd.DataFrame
     beta: Optional[FLOAT]
+    rsquared: Optional[FLOAT]
 
     def __init__(self, investmentinfo: pd.DataFrame, data: pd.Series) -> None:
         """
@@ -63,6 +66,8 @@ class Stock(Asset):
         super().__init__(data, self.name, asset_type="Stock")
         # beta parameter of stock (CAPM)
         self.beta = None
+        # R squared coefficient of stock
+        self.rsquared = None
 
     def comp_beta(self, market_daily_returns: pd.Series) -> FLOAT:
         """Computes and returns the Beta parameter of the stock.
@@ -83,10 +88,28 @@ class Stock(Asset):
         self.beta = beta
         return beta
 
+    def comp_rsquared(self, market_daily_returns: pd.Series) -> FLOAT:
+        """Computes and returns the R squared coefficient of the stock.
+
+        :param market_daily_returns: Daily returns of the market index.
+
+        :rtype: :py:data:`~.finquant.data_types.FLOAT`
+        :return: R squared coefficient of the stock
+        """
+        # Type validations:
+        type_validation(market_daily_returns=market_daily_returns)
+
+        rsquared = r2_score(
+            market_daily_returns.to_frame()[market_daily_returns.name],
+            self.comp_daily_returns(),
+        )
+        self.rsquared = rsquared
+        return rsquared
+
     def properties(self) -> None:
         """Nicely prints out the properties of the stock: Expected Return,
-        Volatility, Beta (optional), Skewness, Kurtosis as well as the ``Allocation`` (and other
-        information provided in investmentinfo.)
+        Volatility, Beta (optional), R squared (optional), Skewness, Kurtosis as well as the ``Allocation``
+        (and other information provided in investmentinfo.)
         """
         # nicely printing out information and quantities of the stock
         string = "-" * 50
@@ -95,6 +118,8 @@ class Stock(Asset):
         string += f"\nVolatility: {self.volatility:0.3f}"
         if self.beta is not None:
             string += f"\n{self.asset_type} Beta: {self.beta:0.3f}"
+        if self.rsquared is not None:
+            string += f"\n{self.asset_type} R squared: {self.rsquared:0.3f}"
         string += f"\nSkewness: {self.skew:0.5f}"
         string += f"\nKurtosis: {self.kurtosis:0.5f}"
         string += "\nInformation:"

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -98,9 +98,11 @@ class Stock(Asset):
         # Type validations:
         type_validation(market_daily_returns=market_daily_returns)
 
-        rsquared = r2_score(
-            market_daily_returns.to_frame()[market_daily_returns.name],
-            self.comp_daily_returns(),
+        rsquared = float(
+            r2_score(
+                market_daily_returns.to_frame()[market_daily_returns.name],
+                self.comp_daily_returns(),
+            )
         )
         self.rsquared = rsquared
         return rsquared

--- a/finquant/stock.py
+++ b/finquant/stock.py
@@ -27,12 +27,11 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+from sklearn.metrics import r2_score
 
 from finquant.asset import Asset
 from finquant.data_types import FLOAT
 from finquant.type_utilities import type_validation
-
-from sklearn.metrics import r2_score
 
 
 class Stock(Asset):

--- a/finquant/type_utilities.py
+++ b/finquant/type_utilities.py
@@ -145,6 +145,7 @@ type_dict: Dict[
     "mu": ((float, np.floating), None),
     "sigma": ((float, np.floating), None),
     "conf_level": ((float, np.floating), None),
+    "beta_parameter": ((float, np.floating), None),
     # INTs:
     "freq": ((int, np.integer), None),
     "span": ((int, np.integer), None),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=2.0
 matplotlib>=3.0
 quandl>=3.4.5
 yfinance>=0.1.43
+sklearn>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas>=2.0
 matplotlib>=3.0
 quandl>=3.4.5
 yfinance>=0.1.43
-sklearn>=1.3.0
+scikit-learn>=1.3.0

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -41,3 +41,4 @@ def test_Market():
     assert pf.market_index.name == "^GSPC"
     assert pf.beta is not None
     assert pf.rsquared is not None
+    assert pf.treynor is not None

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -40,3 +40,4 @@ def test_Market():
     assert isinstance(pf.market_index, Market)
     assert pf.market_index.name == "^GSPC"
     assert pf.beta is not None
+    assert pf.rsquared is not None

--- a/tests/test_quants.py
+++ b/tests/test_quants.py
@@ -9,6 +9,7 @@ from finquant.quants import (
     downside_risk,
     sharpe_ratio,
     sortino_ratio,
+    treynor_ratio,
     value_at_risk,
     weighted_mean,
     weighted_std,
@@ -42,6 +43,11 @@ def test_sharpe_ratio():
 def test_sortino_ratio():
     assert sortino_ratio(0.5, 0.0, 0.02) is np.NaN
     assert sortino_ratio(0.005, 8.5, 0.005) == 0.0
+
+
+def test_treynor_ratio():
+    assert treynor_ratio(0.2, 0.9, 0.002) == 0.22
+    assert treynor_ratio(0.005, 0.92, 0.005) == 0.0
 
 
 def test_value_at_risk():

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-version=0.6.2
-release=0.6.2
+version=0.7.0
+release=0.7.0


### PR DESCRIPTION
The R-squared coefficient measures how closely the portfolio's returns track the benchmark market index's returns. On the other hand, the Treynor Ratio is a metric used to evaluate an investment portfolio's risk-adjusted returns. 

They have been incorporated in the same PR to simplify the merging, and because such parameters both refer to the market index. 